### PR TITLE
Make RestGoal duration the correct duration

### DIFF
--- a/examples/goal/src/Goals.js
+++ b/examples/goal/src/Goals.js
@@ -47,7 +47,7 @@ class RestGoal extends Goal {
 
 		owner.currentTime += owner.deltaTime;
 
-		if ( owner.currentTime >= owner.pickUpDuration ) {
+		if ( owner.currentTime >= owner.restDuration ) {
 
 			owner.currentTime = 0;
 			owner.currentTarget = null;


### PR DESCRIPTION
Before accidentally the `pickUpDuration` was used instead of `restDuration`